### PR TITLE
Update ipmi_fancontrol-ng

### DIFF
--- a/ipmi_fancontrol-ng
+++ b/ipmi_fancontrol-ng
@@ -43,7 +43,7 @@ $hostname =~ s/\n//g;
 #my $number_of_fanbanks  = 1; # Number of BANKs of FANs to update
 my $number_of_fanbanks  = 2; # Number of BANKs of FANs to update
 my $min_temp_change     = 0; # *C minimum change to actually cause a fan speed update
-my $seconds_to_sleep    = 5; # Number of seconds to sleep between update loops
+my $seconds_to_sleep    = 0; # Number of seconds to sleep between update loops
 
 # IPMI Configuration
 #my $ipmi_username       = "username_goes_here";


### PR DESCRIPTION
Set the update time to 0 seconds. This forces the fan speed change to occur constantly. 

IMM no longer has a chance to ramp up fans noticeably, with little to no noticeable effect on CPU or resource usage.